### PR TITLE
Update kde-plasma/lxqt-panel.qss and add overbars

### DIFF
--- a/themes/kde-plasma/lxqt-panel.qss
+++ b/themes/kde-plasma/lxqt-panel.qss
@@ -49,14 +49,15 @@ QMenu {
     margin: 0px;
     color: #313639;
 }
+
 QMenu QToolButton {
     background-color: transparent;
     color: black;
     font: bold;
-	/* padding and border guarantee that it won't be drawn by widget style */
-	padding: 1px;
-	border: none;
-	font: bold;
+    /* padding and border guarantee that it won't be drawn by widget style */
+    padding: 1px;
+    border: none;
+    font: bold;
 }
 
 QMenu::item {
@@ -102,13 +103,15 @@ QMenu::indicator:non-exclusive:checked {
 #MainMenu {
     color: rgba(54, 54, 54, 100%);
     margin: 3px;
+    margin-right: 0px;
     padding-top: 2px;
     border-top: 3px solid transparent;
     qproperty-icon: url(mainmenu.svg);
 }
 
+#MainMenu:on,
 #MainMenu:hover {
-    border-top: 3px solid #1E91FE;
+    border-top: 3px solid rgba(30, 145, 255, 50%);
 }
 
 #MainMenu QLineEdit {
@@ -147,21 +150,60 @@ QMenu::indicator:non-exclusive:checked {
 }
 
 /*
+ * DirectoryMenu
+ */
+
+#DirectoryMenu {
+        margin: 3px;
+	padding-top: 2px;
+	border-top: 3px solid transparent;
+}
+
+#DirectoryMenu:on,
+#DirectoryMenu:hover {
+	border-top: 3px solid rgba(30, 145, 255, 50%);
+}
+
+/*
+ * Backlight
+ */
+
+#Backlight {
+    margin: 3px;
+    padding-top: 2px;
+    border-top: 3px solid transparent;
+}
+
+#Backlight:on,
+#Backlight:hover {
+    border-top: 3px solid rgba(30, 145, 255, 50%);
+}
+
+/*
+ * Sensors
+ */
+
+#Sensors {
+    margin: 3px;
+}
+
+/*
  * TaskBar
  */
-#TaskBar QToolButton{
+
+#TaskBar QToolButton {
     margin: 3px;
     padding-top: 2px;
     border-top: 3px solid #DEDEDE;
     color: rgba(54, 54, 54, 60%);
 }
 
-#TaskBar QToolButton:on{
+#TaskBar QToolButton:on {
     border-top: 3px solid rgba(30, 145, 255, 100%);
     color: rgba(54, 54, 54, 100%);
 }
 
-#TaskBar QToolButton:hover{
+#TaskBar QToolButton:hover {
     border-top: 3px solid rgba(30, 145, 255, 50%);
     color: rgba(54, 54, 54, 100%);
 }
@@ -178,6 +220,7 @@ QMenu::indicator:non-exclusive:checked {
  /*
  * QuickLaunch
  */
+
 #QuickLaunchPlaceHolder {
     color: #1e91ff;
     padding: 0 5px;
@@ -185,6 +228,7 @@ QMenu::indicator:non-exclusive:checked {
 
 #QuickLaunch QToolButton{
     margin: 3px;
+    margin-right: 0px;
     padding-top: 2px;
     border-top: 3px solid transparent;
     color: rgba(54, 54, 54, 60%);
@@ -198,8 +242,10 @@ QMenu::indicator:non-exclusive:checked {
 /*
  * Volume plugin
  */
+
 #VolumePlugin QToolButton {
     margin: 3px;
+    margin-right: 0px;
     padding-top: 2px;
     border-top: 3px solid transparent;
     color: rgba(54, 54, 54, 60%);
@@ -292,14 +338,15 @@ VolumePopup  > QSlider::sub-page:vertical {
 /*
  * Mount plugin
  */
-#LXQtMountPlugin MountButton{
+
+#LXQtMountPlugin QToolButton {
     margin: 3px;
     padding-top: 2px;
     border-top: 3px solid transparent;
     color: rgba(54, 54, 54, 60%);
 }
 
-#LXQtMountPlugin MountButton:hover{
+#LXQtMountPlugin QToolButton:hover {
     border-top: 3px solid rgba(30, 145, 255, 50%);
     color: rgba(54, 54, 54, 100%);
 }
@@ -436,8 +483,14 @@ TrayIcon {
  */
 
 #WorldClockContent {
-    margin: 2px;
+    margin: 3px;
+    border-top: 3px solid transparent;
     color: rgba(54, 54, 54, 100%);
+}
+
+#WorldClockContent:on,
+#WorldClockContent:hover {
+    border-top: 3px solid rgba(30, 145, 255, 50%);
 }
 
 /*
@@ -447,7 +500,6 @@ TrayIcon {
 #LXQtCpuLoad {
     qproperty-fontColor: #cacaca;
 }
-
 
 /*
  * Calendar Widget


### PR DESCRIPTION
According to the discussion in #57.

- Added overbars to Backlight, Directory Menu, Mount, World Clock
- Added vertical padding to Sensors
- Whitespace cleanup

Currently the `:on` pseudo-state isn't working in Directory Menu and World Clock